### PR TITLE
Adds an option for cdn (i.e. cloudfront) as base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ module.exports = ({ env }) => ({
 
 You can see another Sharp Optimize Options [here](https://sharp.pixelplumbing.com/api-output#jpeg) and AWS S3 Params [here](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property)
 
+If you want to use a cdn instead of direct S3 access, you can just add a cdn url (i.e. https://whatever.cloudfront.net) to the config:
+
+```js
+module.exports = ({ env }) => ({
+  upload: {
+    provider: 'aws-s3-resizing-and-optimisation',
+    providerOptions: {
+      accessKeyId: env('AWS_ACCESS_KEY_ID'),
+      secretAccessKey: env('AWS_ACCESS_SECRET'),
+      region: env('AWS_REGION'),
+      cnd: env('CLOUDFRONT')
+      ...
+```
 
 ## AWS S3 Bucket structure
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ module.exports = {
       ...config,
     });
 
-    const S3BaseUrl = `https://${config.params.Bucket}.s3.${config.region}.amazonaws.com`;
+    const S3BaseUrl = config.cdn ? config.cdn : `https://${config.params.Bucket}.s3.${config.region}.amazonaws.com`;
 
     function getFileType(file) {
       let fileType = 'origin';


### PR DESCRIPTION
Nice job, was about to do something similar myself and then found this. The only thing I felt was missing was being able to use cloudfront as the base url. Pretty straightforward change and shouldnt clash with anything.