### PR TITLE
Update sharp to 0.28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.772.0",
-    "sharp": "^0.29.1"
+    "sharp": "^0.28.1"
   },
   "devDependencies": {
     "eslint": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.772.0",
-    "sharp": "^0.26.2"
+    "sharp": "^0.29.1"
   },
   "devDependencies": {
     "eslint": "^6.0.1"


### PR DESCRIPTION
Updates the sharp dependency to the same as the one used in `strapi-plugin-upload@3.6.8` (the current version of the plugin at the time of this PR).

This fixes the issue described here: https://github.com/YegorShtonda/strapi-provider-upload-aws-s3-resizing-and-optimisation/issues/10